### PR TITLE
Add support for class-based views in route decorator

### DIFF
--- a/route_decorator.py
+++ b/route_decorator.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Callable, Dict, List, Tuple, Union
 
 from django import urls
@@ -27,7 +28,12 @@ class Route:
                 urlpath = urlpath.replace("__", "/")  # type: ignore
             urlpath = urlpath.replace("_", "-")  # type: ignore
             urlpath = self.url_prefix + "/" + urlpath.lstrip("/")
-            self.routes[urlname] = urlpath, f
+            
+            # Check if f is a class with an as_view method
+            if inspect.isclass(f) and hasattr(f, 'as_view'):
+                self.routes[urlname] = urlpath, f.as_view()
+            else:
+                self.routes[urlname] = urlpath, f
             return f
 
         if callable(path):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if sys.argv[-1] == "publish":
     sys.exit(0)
 
 setup(
-    version="0.1.1",
+    version="0.2.0",
     name="django-route-decorator",
     description="A flask-style `route` decorator for django views",
     long_description=open("./README.md").read(),

--- a/tests.py
+++ b/tests.py
@@ -45,3 +45,32 @@ def test_with_prefixes():
         pass
 
     assert route.names["api:bar-name"] == "/api/bar"
+
+
+def test_with_class_as_view():
+    route = Route()
+
+    @route("/test", name="test-view")
+    class TestView:
+        @staticmethod
+        def as_view():
+            def view_func(request):
+                pass
+            return view_func
+
+    @route
+    def foo_view(request):
+        pass
+
+
+    assert len(route.names) == 2
+    assert route.names["foo_view"] == "/foo-view"
+    assert route.names["test-view"] == "/test"
+
+    assert len(route.patterns) == 2
+    assert (
+        str(route.patterns[1]) == "<URLPattern 'foo-view' [name='foo_view']>"
+    )
+    assert (
+        str(route.patterns[0]) == "<URLPattern 'test' [name='test-view']>"
+    )


### PR DESCRIPTION
This pull request adds support for class-based views in the route decorator. It introduces a check to see if the decorated function is a class with an `as_view` method. If it is, the `as_view` method is used as the view function for the route.

```python
@route("/myview", name="my-view")
class MyView(View):
   ...
```